### PR TITLE
fix: adapt filterByRectangle to documentclient

### DIFF
--- a/src/GeoDataManager.ts
+++ b/src/GeoDataManager.ts
@@ -354,7 +354,7 @@ export class GeoDataManager {
     const latLngRect: S2LatLngRect = S2Util.latLngRectFromQueryRectangleInput(geoQueryInput);
 
     return list.filter(item => {
-      const geoJson: string = item[this.config.geoJsonAttributeName].S;
+      const geoJson: string = item[this.config.geoJsonAttributeName];
       const coordinates = JSON.parse(geoJson).coordinates;
       const longitude = coordinates[this.config.longitudeFirst ? 0 : 1];
       const latitude = coordinates[this.config.longitudeFirst ? 1 : 0];

--- a/test/integration/example.ts
+++ b/test/integration/example.ts
@@ -93,6 +93,30 @@ describe('Example', function () {
     }]);
   });
 
+  it('queryRectangle', async function () {
+    this.timeout(20000);
+    // Perform a rectangle query
+    const result = await capitalsManager.queryRectangle({
+      MinPoint: {
+        latitude: 50.30000,
+        longitude: -2.001
+      },
+      MaxPoint: {
+        latitude: 51.80000,
+        longitude: 2.001
+      }
+    })
+
+    expect(result).to.deep.equal([{
+      rangeKey: "50",
+      country: 'United Kingdom',
+      capital: 'London',
+      hashKey: 522,
+      geoJson: '{"type":"Point","coordinates":[-0.13,51.51]}',
+      geohash: 5221366118452580000
+    }]);
+  });
+
   after(async function () {
     this.timeout(10000);
     await ddb.deleteTable({ TableName: config.tableName }).promise()


### PR DESCRIPTION
`filterByRectangle` still had the `.S` for `geoJson`, which made the function break. This PR fixes it and adds a unit test for `queryRectangle`